### PR TITLE
SUBX.L should calc flags using Long value

### DIFF
--- a/src/m68k/cpu/instructions/SUBX.java
+++ b/src/m68k/cpu/instructions/SUBX.java
@@ -224,7 +224,7 @@ public class SUBX implements InstructionHandler
 		int d = cpu.readMemoryLong(cpu.getAddrRegisterLong(rx));
 		int r = d - s - (cpu.isFlagSet(Cpu.X_FLAG) ? 1 : 0);
 		cpu.writeMemoryLong(cpu.getAddrRegisterLong(rx), r);
-		cpu.calcFlags(InstructionType.SUBX, s, d, r, Size.Byte);
+		cpu.calcFlags(InstructionType.SUBX, s, d, r, Size.Long);
 		return 30;
 	}
 


### PR DESCRIPTION
#13 SUBX.L should use Long value for calculating CPU flags.